### PR TITLE
商品一覧機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,7 +15,7 @@ class ItemsController < ApplicationController
   end
 
   def index
-    @items = Item.all
+    @items = Item.order(created_at: :desc)
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,12 +25,3 @@ class ItemsController < ApplicationController
                                  :scheduled_delivery_id, :price, :image)
   end
 end
-
-# def create
-# @item = Item.new(item_params)
-# if @item.save
-# redirect_to root_path
-# else
-# render :new
-# end
-# end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,6 +15,7 @@ class ItemsController < ApplicationController
   end
 
   def index
+    @items = Item.all
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -155,8 +155,6 @@
             </li>
           <% end %>
         <% else %>
-          <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-          <%# 商品がある場合は表示されないようにしましょう %>
           <li class='list'>
             <%= link_to '#' do %>
               <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,8 +172,6 @@
               </div>
             <% end %>
           </li>
-          <%# //商品がある場合は表示されないようにしましょう %>
-          <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
         <% end %>
       </ul>
     </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -121,65 +121,64 @@
   <%# /FURIMAの特徴 %>
 
   <%# 商品一覧 %>
-  <div class='item-contents'>
-    <h2 class='title'>ピックアップカテゴリー</h2>
-    <div class="subtitle" >
-      新規投稿商品
+    <div class='item-contents'>
+      <h2 class='title'>ピックアップカテゴリー</h2>
+      <div class="subtitle" >
+        新規投稿商品
+      </div>
+      <ul class='item-lists'>
+        <% if @items.present? %>
+          <% @items.each do |item| %>
+            <li class='list'>
+              <%= link_to "#" do %>
+                <div class='item-img-content'>
+                  <%= image_tag item.image, class: "item-img" %>
+                  <%# 商品が売れていればsold outを表示しましょう %>
+                  <div class='sold-out'>
+                    <span>Sold Out!!</span>
+                  </div>
+                  <%# //商品が売れていればsold outを表示しましょう %>
+                </div>
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                    <%= item.name %>
+                  </h3>
+                  <div class='item-price'>
+                    <span><%= item.price %>円<br><%= item.shipping_fee_status ? item.shipping_fee_status.name : 'N/A' %></span>
+                    <div class='star-btn'>
+                      <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </li>
+          <% end %>
+        <% else %>
+          <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <%# 商品がある場合は表示されないようにしましょう %>
+          <li class='list'>
+            <%= link_to '#' do %>
+              <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                商品を出品してね！
+               </h3>
+                <div class='item-price'>
+                  <span>99999999円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
+          <%# //商品がある場合は表示されないようにしましょう %>
+          <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        <% end %>
+      </ul>
     </div>
-    <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
-  </div>
   <%# /商品一覧 %>
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
-    name { Faker::Lorem.words(number: 2).join(' ') } 
-    info { Faker::Lorem.sentences } 
-    category_id { Faker::Number.between(from: 2, to: 11) } 
-    sales_status_id { Faker::Number.between(from: 2, to: 7) } 
-    shipping_fee_status_id { Faker::Number.between(from: 2, to: 3) } 
-    prefecture_id { Faker::Number.between(from: 2, to: 48) } 
-    scheduled_delivery_id { Faker::Number.between(from: 2, to: 4) } 
-    price { Faker::Number.between(from: 300, to: 9_999_999) } 
+    name { Faker::Lorem.words(number: 2).join(' ') }
+    info { Faker::Lorem.sentences }
+    category_id { Faker::Number.between(from: 2, to: 11) }
+    sales_status_id { Faker::Number.between(from: 2, to: 7) }
+    shipping_fee_status_id { Faker::Number.between(from: 2, to: 3) }
+    prefecture_id { Faker::Number.between(from: 2, to: 48) }
+    scheduled_delivery_id { Faker::Number.between(from: 2, to: 4) }
+    price { Faker::Number.between(from: 300, to: 9_999_999) }
     association :user
 
     after(:build) do |item|


### PR DESCRIPTION
「what」
　『売却済みの商品は、画像上に「sold out」の文字が表示されること。』以外実装。

　〇プルリクエストへ記載するgyazo
　　出品がないとダミーが表示される動画。
　　https://gyazo.com/1aacd574f35fbff49aa7896b495cff5e

　〇左上から、出品された日時が新しい順に表示されること。
　　https://gyazo.com/0eba350c7d353a595b97b141f220c90e

「why」
　商品一覧表示機能実装のため。

Rubocop実施済みです。
お忙しい中誠に恐れ入りますがコードレビューしていただけますと幸いです。
よろしくお願い申し上げます。